### PR TITLE
Update formatted_ext_patterns.tsv

### DIFF
--- a/resources/formatted_ext_patterns.tsv
+++ b/resources/formatted_ext_patterns.tsv
@@ -44,7 +44,7 @@ regulates_o_results_in_formation_of	EMAPA,UBERON,WBbt	GO:0022603
 adjacent_to	CL,WBbt	GO:0022603	
 exists_during	GO:P,WBls	GO:0005575	
 results_in_commitment_to	CL,WBbt	GO:0045165	
-regulates_transcription_of	geneID	GO:0045165	
+regulates_transcription_of	geneID	GO:1903506  
 regulates_o_has_input	geneID	GO:0008150,GO:0003674	
 regulates_o_has_input	CL,WBbt,CHEBI	GO:0008150	
 has_direct_input	PR	GO:0008150,GO:0003674	


### PR DESCRIPTION
Updated GO term for use with 'regulates transcription of'.

It was associated with 'cell fate commitment' (GO:0045615) which I think might have just been a typo from repeating the GO term in the previous entry for 'results in commitment to'.

This should allow more annotation lines to pass.