### PR TITLE
Update formatted_ext_patterns.tsv

### DIFF
--- a/resources/formatted_ext_patterns.tsv
+++ b/resources/formatted_ext_patterns.tsv
@@ -51,8 +51,7 @@ has_agent	CL,WBbt	GO:0008150
 part_of	geneID,GO:P	GO:0008150	
 part_of	CL,WBbt	GO:0010453	
 part_of	EMAPA,UBERON,WBbt	GO:0008150,GO:0003674	
-results_in_specification_of	CL,WBbt	GO:0001708	
-results_in_specification_of	EMAPA,UBERON,WBbt	GO:1903429	
+results_in_specification_of	CL,WBbt	GO:0001708		
 negatively_regulates	geneID	GO:0008150,GO:0003674	
 negatively_regulates	GO:P	GO:0008150	
 negatively_regulates	GO:F	GO:0005488	

--- a/resources/formatted_ext_patterns.tsv
+++ b/resources/formatted_ext_patterns.tsv
@@ -51,7 +51,7 @@ has_agent	CL,WBbt	GO:0008150
 part_of	geneID,GO:P	GO:0008150	
 part_of	CL,WBbt	GO:0010453	
 part_of	EMAPA,UBERON,WBbt	GO:0008150,GO:0003674	
-results_in_specification_of	CL,WBbt	GO:0001708		
+results_in_specification_of	CL,WBbt	GO:0001708	
 negatively_regulates	geneID	GO:0008150,GO:0003674	
 negatively_regulates	GO:P	GO:0008150	
 negatively_regulates	GO:F	GO:0005488	


### PR DESCRIPTION
Deleting line 55 that used 'results in specification of' with EMAPA,UBERON,WBbt.
This will restrict 'results in specification of' to CL,WBbt